### PR TITLE
Fix: exclude micronaut-aop-3.0.3.jar from bbb-lti

### DIFF
--- a/bbb-lti/build.gradle
+++ b/bbb-lti/build.gradle
@@ -125,6 +125,10 @@ dependencies {
   //testImplementation "org.seleniumhq.selenium:selenium-support:$seleniumVersion"
 }
 
+configurations.implementation {
+    exclude group: 'io.micronaut', module: 'micronaut-aop'
+}
+
 bootRun {
   jvmArgs(
           '-Dspring.output.ansi.enabled=always',


### PR DESCRIPTION
<h3>What does this PR do?</h3>
This PR removes `micronaut-aop-3.0.3.jar` from bbb-lti. It is based on https://github.com/bigbluebutton/bigbluebutton/pull/14614/files

<h3>Motivation</h3>
<p>There was a duplication error caused by this file.</p>
<b>Message: Multiple possible bean candidates found: [io.micronaut.aop.InterceptorRegistry, io.micronaut.aop.InterceptorRegistry]</b>