### PR TITLE
fix: pick value for ltiEndPoint from lti-config.properties

### DIFF
--- a/bbb-lti/grails-app/services/org/bigbluebutton/LtiService.groovy
+++ b/bbb-lti/grails-app/services/org/bigbluebutton/LtiService.groovy
@@ -28,7 +28,14 @@ class LtiService {
 
     boolean transactional = false
 
-    def endPoint = "localhost"
+    Properties properties = new Properties()
+    File propertiesFile = new File('/usr/share/bbb-lti/WEB-INF/classes/lti-config.properties')
+
+    def endPoint = propertiesFile.withInputStream {
+        properties.load(it)
+        return properties."ltiEndPoint"
+    }
+
     def consumers = "demo:welcome"
     def mode = "simple"
     def restrictedAccess = "true"


### PR DESCRIPTION
<h3>What does this PR do?</h3>

It makes the value of lti endpoint be read from `/usr/share/bbb-lti/WEB-INF/classes/lti-config.properties`, which is where it is set according to https://docs.bigbluebutton.org/admin/lti.html

<h3>Motivation</h3>
Previously this XML parameter has been hardcoded to "localhost", while now it displays actual value

<h3>Closes</h3>
bbb-lti: Incorrect launch url